### PR TITLE
Stringnames

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,8 +74,9 @@ async def on_message(message):
 # Control nicknames when a nickname is changed.
 @client.event
 async def on_member_update(before, after):
-    if before.nick != after.nick:
-        await memaction.setNick(gd, after)
+    if after.guild.id in gd:
+        if before.nick != after.nick:
+            await memaction.setNick(gd, after)
 
 
 # Handle events when member leaves the guild it feature enabled

--- a/modules/dnos.py
+++ b/modules/dnos.py
@@ -90,7 +90,6 @@ def formatDrivers(guilddata, guildid):
     membs = guild.members
     for member in membs:
         if member.nick is not None:
-            print(member.nick)
             m = re.match(r"^\d{1,2} \|\| (.+)", member.nick)
             if m is not None:
 
@@ -170,6 +169,17 @@ async def updateDrivers(guilddata, guildid):
 
 
 def gridEmbed(guilddata, guildid, channel):
+    # Get Driver Nicknames
+    nicks = {}
+    guild = _config["client"].get_guild(guildid)
+    membs = guild.members
+    for member in membs:
+        if member.nick is not None:
+            m = re.match(r"^\d{1,2} \|\| (.+)", member.nick)
+            if m is not None:
+
+                nicks[member.id] = m.group(1)
+
     embed = discord.Embed(
         title=channel.name,
         color=discord.Color.gold()
@@ -185,10 +195,10 @@ def gridEmbed(guilddata, guildid, channel):
         d2 = "\u2800" * 4 + "--" + "\u2800" * 4
 
         if guilddata[guildid]["grids"][str(channel.id)]["grid"][team][0] is not None:
-            d1 = "<@" + str(guilddata[guildid]["grids"][str(channel.id)]["grid"][team][0]) + ">"
+            d1 = nicks[guilddata[guildid]["grids"][str(channel.id)]["grid"][team][0]]
 
         if guilddata[guildid]["grids"][str(channel.id)]["grid"][team][1] is not None:
-            d2 = "<@" + str(guilddata[guildid]["grids"][str(channel.id)]["grid"][team][1]) + ">"
+            d2 = nicks[guilddata[guildid]["grids"][str(channel.id)]["grid"][team][1]]
 
         embed.add_field(
             name=f"{temoji} {team}",

--- a/modules/dnos.py
+++ b/modules/dnos.py
@@ -5,6 +5,7 @@ import sys
 import json
 import discord
 import time
+import re
 from . import permissions
 
 # Module-wide globals
@@ -83,32 +84,44 @@ def removeConfig(gid):
 
 
 def formatDrivers(guilddata, guildid):
+    # Get Driver Nicknames
+    nicks = {}
+    guild = _config["client"].get_guild(guildid)
+    membs = guild.members
+    for member in membs:
+        if member.nick is not None:
+            print(member.nick)
+            m = re.match(r"^\d{1,2} \|\| (.+)", member.nick)
+            if m is not None:
+
+                nicks[member.id] = m.group(1)
+
     template = ["", "", ""]
     for i in range(1, 10):
         template[0] += f"` {i}` - "
         if guildid in guilddata and str(i) in guilddata[guildid]["numbers"]:
-            template[0] += f"<@{guilddata[guildid]['numbers'][str(i)]}>"
+            template[0] += f"{nicks[guilddata[guildid]['numbers'][str(i)]]}"
         else:
             template[0] += "\u2800" * 4 + "--" + "\u2800" * 4
         template[0] += "\n"
     for i in range(10, 34):
         template[0] += f"`{i}` - "
         if guildid in guilddata and str(i) in guilddata[guildid]["numbers"]:
-            template[0] += f"<@{guilddata[guildid]['numbers'][str(i)]}>"
+            template[0] += f"{nicks[guilddata[guildid]['numbers'][str(i)]]}"
         else:
             template[0] += "\u2800" * 4 + "--" + "\u2800" * 4
         template[0] += "\n"
     for i in range(34, 67):
         template[1] += f"`{i}` - "
         if guildid in guilddata and str(i) in guilddata[guildid]["numbers"]:
-            template[1] += f"<@{guilddata[guildid]['numbers'][str(i)]}>"
+            template[1] += f"{nicks[guilddata[guildid]['numbers'][str(i)]]}"
         else:
             template[1] += "\u2800" * 4 + "--" + "\u2800" * 4
         template[1] += "\n"
     for i in range(67, 100):
         template[2] += f"`{i}` - "
         if guildid in guilddata and str(i) in guilddata[guildid]["numbers"]:
-            template[2] += f"<@{guilddata[guildid]['numbers'][str(i)]}>"
+            template[2] += f"{nicks[guilddata[guildid]['numbers'][str(i)]]}"
         else:
             template[2] += "\u2800" * 4 + "--" + "\u2800" * 4
         template[2] += "\n"

--- a/modules/memaction.py
+++ b/modules/memaction.py
@@ -47,6 +47,18 @@ async def setNick(guilddata, member, message=None):
                                        "Bot must be a higher rank than the member. "
                                        "Guild owner must manually set nickname.")
 
+    # Check if grids or numbers need to be updated
+    if member.id in guilddata[member.guild.id]["numbers"].values():
+        await dnos.updateDrivers(guilddata, member.guild.id)
+    for grid in guilddata[member.guild.id]["grids"]:
+        changed = False
+        for team in guilddata[member.guild.id]["grids"][grid]["grid"]:
+            for driver in guilddata[member.guild.id]["grids"][grid]["grid"][team]:
+                if driver == member.id:
+                    changed = True
+        if changed:
+            await dnos.updateEmbed(guilddata, member.guild.id, member.guild.get_channel(int(grid)))
+
     return
 
 


### PR DESCRIPTION
Due to clientside issues with caching @ names causing 'unknown' and ids to be displayed in embeds, revert to just using strings of driver names on tables, and updating these whenever they are changed.